### PR TITLE
Fix check-mk installation error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM debian
 MAINTAINER Paul Smith code@uvwxy.de
 
 # dependency setup
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list
+
 RUN apt-get update
 RUN apt-get install -y \
 		check-mk-livestatus \


### PR DESCRIPTION
This error shows due to missing repository:

```
E: Package 'check-mk-livestatus' has no installation candidate
The command '/bin/sh -c apt-get install -y 		check-mk-livestatus 		build-essential 		libapache2-mod-python 		nagios3 		python 		sudo' returned a non-zero code: 100
make: *** [image] Error 1
```