### PR TITLE
Pre-configure Nagios admin password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM debian
 MAINTAINER Paul Smith code@uvwxy.de
 
 # dependency setup
+RUN echo "nagios3-cgi nagios3/adminpassword string admin" | debconf-set-selections
+RUN echo "nagios3-cgi nagios3/adminpassword-repeat string admin" | debconf-set-selections
 RUN apt-get update
 RUN apt-get install -y \
 		check-mk-livestatus \


### PR DESCRIPTION
Nagios admin password set to `admin`. This avoids the Docker build asking for user input; i.e.:

```
Configuring nagios3-cgi
-----------------------

Please provide the password to be created with the "nagiosadmin" user.

This is the username and password you will use to log in to your nagios
installation after configuration is complete.  If you do not provide a password,
you will have to configure access to nagios yourself.

Nagios web administration password:
```