### PR TITLE
Fix check-mk-livestatus installation error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:wheezy
 MAINTAINER Paul Smith code@uvwxy.de
 
 # dependency setup


### PR DESCRIPTION
The current build is failing because Debian have changed their `latest` release to Jessie while this project relies on Wheezy:

```
E: Package 'check-mk-livestatus' has no installation candidate
The command '/bin/sh -c apt-get install -y      check-mk-livestatus         build-essential         libapache2-mod-python       nagios3         python      sudo' returned a non-zero code: 100
make: *** [image] Error 1
```

I tried using Jessie instead by adding the `wheezy-backports` repositories but there's more work to be done before this project can work with Jessie (see PR#2).
